### PR TITLE
Use python from environment override

### DIFF
--- a/src/apActions.ts
+++ b/src/apActions.ts
@@ -497,7 +497,7 @@ export class apActionItem extends vscode.TreeItem {
 			env: terminalEnv
 		});
 		terminal.sendText(`cd ${workspaceRoot}`);
-		const simVehicleCommand = `python3 ${simVehiclePath} --no-rebuild -v ${vehicleType} ${additionalArgs} ${config.simVehicleCommand || ''}`;
+		const simVehicleCommand = `${ProgramUtils.TOOL_PYTHON} ${simVehiclePath} --no-rebuild -v ${vehicleType} ${additionalArgs} ${config.simVehicleCommand || ''}`;
 		terminal.sendText(simVehicleCommand);
 		terminal.show();
 	}


### PR DESCRIPTION
It seems like when running SITL the environment variable override is not respected.
Proposing a fix for the same 