### PR TITLE
WSL to use the currently running instance's path

### DIFF
--- a/src/apLaunch.ts
+++ b/src/apLaunch.ts
@@ -1159,10 +1159,9 @@ export class APLaunchConfigurationProvider implements vscode.DebugConfigurationP
 		const openOCDPath = openOCD.path;
 		if (ProgramUtils.isWSL()) {
 			// convert to using wsl path by appending \\wsl.localhost\Ubuntu
-			const wslDistro = ProgramUtils.wslDistro();
-			openOCDHelperPath = `\\\\\\\\wsl.localhost\\${wslDistro}${openOCDHelperPath.replace(/\//g, '\\')}`;
-			openocdScriptPath = `\\\\\\\\wsl.localhost\\${wslDistro}${openocdScriptPath.replace(/\//g, '\\')}`;
-
+			const wslDistroPath = ProgramUtils.wslDistroPath();
+			openOCDHelperPath = `${wslDistroPath}${openOCDHelperPath.replace(/\//g, '\\')}`;
+			openocdScriptPath = `${wslDistroPath}${openocdScriptPath.replace(/\//g, '\\')}`;
 		}
 
 		APLaunchConfigurationProvider.log.log(`HARDWARE_DEBUG: Starting debug session for ${config.board}`);
@@ -1259,7 +1258,7 @@ export class APLaunchConfigurationProvider implements vscode.DebugConfigurationP
 		if (fs.existsSync(pluginPath)) {
 			APLaunchConfigurationProvider.log.log(`RTOS_PLUGIN: Found plugin for ${platform}: ${pluginPath}`);
 			if (ProgramUtils.isWSL()) {
-				pluginPath = `\\\\\\\\wsl.localhost\\${ProgramUtils.wslDistro()}${pluginPath.replace(/\//g, '\\')}`;
+				pluginPath = `${ProgramUtils.wslDistroPath()}${pluginPath.replace(/\//g, '\\')}`;
 			}
 			return pluginPath;
 		} else {

--- a/src/apProgramUtils.ts
+++ b/src/apProgramUtils.ts
@@ -390,24 +390,21 @@ export class ProgramUtils {
 	}
 
 	/**
-	 * Gets the WSL distribution name
-	 * @returns The WSL distribution name, or 'Ubuntu' if not in WSL
-	 */
-	public static wslDistro(): string {
+     * Gets the WSL distribution name
+     * @returns The WSL distribution name, or 'Ubuntu' if not in WSL
+     */
+	public static wslDistroPath(): string {
 		// Get the WSL distribution name
 		try {
-			const osRelease = child_process.spawnSync('cat', ['/etc/os-release'], { stdio: 'pipe' });
-			if (osRelease.status === 0) {
-				const output = osRelease.stdout.toString();
-				const nameMatch = output.match(/^NAME="?([^"\n]+)"?/m);
-				const distroName = nameMatch ? nameMatch[1] : 'Ubuntu';
-				ProgramUtils.log.log(`WSL distribution from /etc/os-release: ${distroName}`);
-				return distroName;
+			const osLocation = child_process.execSync('cd / && pwd.exe');
+			if (osLocation) {
+				const distroPath = osLocation.toString().replace(/(\r|\n)/g,'');
+				return distroPath;
 			}
 		} catch (error) {
 			ProgramUtils.log.log(`Error reading /etc/os-release: ${error}`);
 		}
-		return 'Ubuntu';
+		return '//wsl.localhost/Ubuntu';
 	}
 
 	/**


### PR DESCRIPTION
WSL to use the currently running instance's path. Without this patch it assumes "Ubuntu" and with it it can get "Ubuntu_22.04" or whatever the WSL's name is called.