### PR TITLE
Add Force Update Submodules command to Welcome view

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,11 @@
         "command": "apActions.distclean",
         "title": "Distclean Build Artifacts",
         "icon": "$(clear-all)"
+      },
+      {
+        "command": "ardupilot.forceUpdateSubmodules",
+        "title": "Force Update Submodules",
+        "icon": "$(sync)"
       }
     ],
     "menus": {

--- a/src/apForceUpdateSubmodules.ts
+++ b/src/apForceUpdateSubmodules.ts
@@ -1,0 +1,115 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+	Copyright (c) 2024 Siddharth Purohit, CubePilot Global Pty Ltd.
+*/
+
+import * as vscode from 'vscode';
+import { simpleGit, SimpleGitProgressEvent } from 'simple-git';
+import { apWelcomeItem } from './apWelcomeItem';
+
+export class ForceUpdateSubmodules extends apWelcomeItem {
+
+	constructor(
+		label: string,
+		collapsibleState: vscode.TreeItemCollapsibleState
+	) {
+		super(label, collapsibleState);
+		this.command = {
+			command: 'ardupilot.forceUpdateSubmodules',
+			title: 'Force Update Submodules'
+		};
+		this.iconPath = new vscode.ThemeIcon('sync');
+	}
+
+	/**
+     * Force update all submodules using the same commands as submodule-sync.sh script
+     * Executes: git submodule update --recursive --force --init (3 times)
+     * and: git submodule sync --recursive (3 times)
+     */
+	private async forceUpdateSubmodulesWithGit(gitBaseDir: string, report: (message: string, increment?: number) => void, abortSignal: AbortSignal): Promise<void> {
+		// Create a git instance configured for progress and cancellation
+		let lastProgress = 0;
+		const progressController = ({ method, stage, progress }: SimpleGitProgressEvent) => {
+			if (method && typeof progress === 'number' && progress >= 0 && progress <= 100) {
+				const delta = progress - lastProgress;
+				if (delta !== 0) {
+					report(`${stage}`, delta);
+					lastProgress = progress;
+				}
+			} else if (stage) {
+				report(`${stage}`);
+			}
+		};
+
+		const git = simpleGit({ baseDir: gitBaseDir, progress: progressController, abort: abortSignal });
+
+		// Check if we're in a git repository
+		const isRepo = await git.checkIsRepo();
+		if (!isRepo) {
+			throw new Error('Not in a Git repository. Please open a Git repository in VS Code workspace.');
+		}
+
+		// Execute the same commands as submodule-sync.sh script
+		// Run 3 times due to poor handling of recursion
+		for (let i = 0; i < 3; i++) {
+			report(`Updating submodules (pass ${i + 1}/3)...`);
+			await git.submoduleUpdate(['--recursive', '--force', '--init']);
+			report(`Syncing submodules (pass ${i + 1}/3)...`);
+			await git.subModule(['sync', '--recursive']);
+		}
+	}
+
+	/**
+     * Show progress indication for submodule operations
+     */
+	showProgress(): void {
+		const workspaceRoot = (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
+			? vscode.workspace.workspaceFolders[0].uri.fsPath
+			: process.cwd();
+
+		vscode.window.withProgress({
+			location: vscode.ProgressLocation.Notification,
+			title: 'Force Updating Submodules',
+			cancellable: true
+		}, async (progress, token) => {
+			const abortController = new AbortController();
+			token.onCancellationRequested(() => {
+				abortController.abort();
+			});
+
+			const report = (message: string, increment?: number) => {
+				if (typeof increment === 'number') {
+					progress.report({ message, increment });
+				} else {
+					progress.report({ message });
+				}
+			};
+
+			try {
+				report('Checking Git repository...');
+				await this.forceUpdateSubmodulesWithGit(workspaceRoot, report, abortController.signal);
+				report('Submodules updated successfully!', 100);
+				vscode.window.showInformationMessage('Submodules force updated successfully!');
+			} catch (error) {
+				if (abortController.signal.aborted) {
+					vscode.window.showWarningMessage('Force update submodules cancelled.');
+					return;
+				}
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				vscode.window.showErrorMessage(`Failed to update submodules: ${errorMessage}`);
+				throw error;
+			}
+		});
+	}
+}

--- a/src/apWelcomeProvider.ts
+++ b/src/apWelcomeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ValidateEnvironment } from './apEnvironmentValidator';
 import { CloneArdupilot } from './apCloneArdupilot';
+import { ForceUpdateSubmodules } from './apForceUpdateSubmodules';
 import { apLog } from './apLog';
 import { apWelcomeItem } from './apWelcomeItem';
 
@@ -14,7 +15,8 @@ export class apWelcomeProvider implements vscode.TreeDataProvider<apWelcomeItem>
 		this.log.log('apWelcomeProvider constructor');
 		this.apWelcomeItems = [
 			new CloneArdupilot('Clone Ardupilot', vscode.TreeItemCollapsibleState.None),
-			new ValidateEnvironment('Validate Environment', vscode.TreeItemCollapsibleState.None)
+			new ValidateEnvironment('Validate Environment', vscode.TreeItemCollapsibleState.None),
+			new ForceUpdateSubmodules('Force Update Submodules', vscode.TreeItemCollapsibleState.None)
 		];
 	}
 
@@ -29,5 +31,12 @@ export class apWelcomeProvider implements vscode.TreeDataProvider<apWelcomeItem>
 	getChildren(): Thenable<apWelcomeItem[]> {
 		// Return both Clone Ardupilot and Validate Environment items
 		return Promise.resolve(this.apWelcomeItems);
+	}
+
+	/**
+	 * Get the ForceUpdateSubmodules instance for command execution
+	 */
+	getForceUpdateSubmodules(): ForceUpdateSubmodules | undefined {
+		return this.apWelcomeItems.find(item => item instanceof ForceUpdateSubmodules) as ForceUpdateSubmodules;
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,6 +153,16 @@ export async function activate(_context: vscode.ExtensionContext): Promise<APExt
 	vscode.commands.registerCommand('connected-devices.disconnectMAVProxy',
 		(device) => apExtensionContext.connectedDevicesProvider?.disconnectDevice(device));
 
+	// Register Force Update Submodules command
+	vscode.commands.registerCommand('ardupilot.forceUpdateSubmodules', () => {
+		const forceUpdateItem = apExtensionContext.apWelcomeProviderInstance?.getForceUpdateSubmodules();
+		if (forceUpdateItem) {
+			forceUpdateItem.showProgress();
+		} else {
+			vscode.window.showErrorMessage('Force Update Submodules feature is not available.');
+		}
+	});
+
 	resolveActive(true);
 	return apExtensionContext;
 }


### PR DESCRIPTION
This pull request introduces a new feature to the VS Code extension that allows users to force update all Git submodules in the workspace, mirroring the behavior of the `submodule-sync.sh` script. The primary changes include adding a new command and UI item for this action, implementing the logic to perform the submodule update with progress feedback, and integrating this feature into the extension's command palette and welcome view.

**New Force Update Submodules Feature:**

* Added a new command, `ardupilot.forceUpdateSubmodules`, to the command palette and welcome UI, allowing users to force-update all Git submodules recursively, with progress indication and error handling. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R299-R303) [[2]](diffhunk://#diff-ceda94883756232ab5b28bb6c3854bf12abd8f5361904ca035417e760c9a1d8dR1-R32) [[3]](diffhunk://#diff-32966dfca6b1dfc2fc8a6d163ce57209aa76fdcc7d298e97cdea7fa4e7b7f6f1L17-R19) [[4]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R157-R162)

**Implementation Details:**

* Implemented the `ForceUpdateSubmodules` class, which extends `apWelcomeItem` and provides the logic to run the submodule update and sync commands multiple times, as per the original script. [[1]](diffhunk://#diff-ceda94883756232ab5b28bb6c3854bf12abd8f5361904ca035417e760c9a1d8dR1-R32) [[2]](diffhunk://#diff-c55a25ab076ac1a8f782cdcb126785c755bded34cd455382992c1d9ad2a2adcaR18-R79)
* Updated the `apWelcomeProvider` to include the new "Force Update Submodules" item in the welcome view.
* Registered the new command in the extension's activation function and ensured it is available throughout the extension. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R30) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R157-R162)

These changes make it easier for users to ensure their submodules are up-to-date directly from the VS Code interface.